### PR TITLE
Add "localHaul" Option for Direct Copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ helm repo update
 #### via GitHub Container Registry
 
 ```bash
-ghcr.io/hauler-dev/charts/hauler
+ghcr.io/hauler-dev/hauler-helm
 ```
 
 #### via Dockerhub Container Registry
 
 ```bash
-docker.io/hauler/charts/hauler
+docker.io/hauler/hauler-helm
 ```
 
 ### Adding the Helm Chart via Rancher Manager

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.1.1
-appVersion: 1.1.1
+version: 1.2.0
+appVersion: 1.2.0

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.1.1
+appVersion: 1.1.1

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.0.4
-appVersion: 1.0.4
+version: 1.0.6
+appVersion: 1.0.6

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.0.6
-appVersion: 1.0.6
+version: 1.0.7
+appVersion: 1.0.7

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.0.8
-appVersion: 1.0.8
+version: 1.1.0
+appVersion: 1.1.0

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.0.7
-appVersion: 1.0.7
+version: 1.0.8
+appVersion: 1.0.8

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.1.1`       | `1.1.1`     |
+| application | `1.2.0`       | `1.2.0`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.1.0`       | `1.1.0`     |
+| application | `1.1.1`       | `1.1.1`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.8`       | `1.0.8`     |
+| application | `1.1.0`       | `1.1.0`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.4`       | `1.0.4`     |
+| application | `1.0.6`       | `1.0.6`     |
 
 ## Installing the Chart
 
@@ -20,13 +20,13 @@ helm upgrade -i hauler hauler-helm/hauler -n hauler-system -f values.yaml
 #### via GitHub Container Registry
 
 ```bash
-helm upgrade -i hauler oci://ghcr.io/hauler-dev/charts/hauler -n hauler-system -f values.yaml
+helm upgrade -i hauler oci://ghcr.io/hauler-dev/hauler-helm -n hauler-system -f values.yaml
 ```
 
 #### via DockerHub Container Registry
 
 ```bash
-helm upgrade -i hauler oci://docker.io/hauler/charts/hauler -n hauler-system -f values.yaml
+helm upgrade -i hauler oci://docker.io/hauler/hauler-helm -n hauler-system -f values.yaml
 ```
 
 ## Helm Chart Deployment Status

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.6`       | `1.0.6`     |
+| application | `1.0.7`       | `1.0.7`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.7`       | `1.0.7`     |
+| application | `1.0.8`       | `1.0.8`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.1.1`       | `1.1.1`     |
+| application | `1.2.0`       | `1.2.0`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.1.0`       | `1.1.0`     |
+| application | `1.1.1`       | `1.1.1`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.8`       | `1.0.8`     |
+| application | `1.1.0`       | `1.1.0`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.4`       | `1.0.4`     |
+| application | `1.0.6`       | `1.0.6`     |
 
 ## Installing the Chart
 
@@ -20,13 +20,13 @@ helm upgrade -i hauler hauler-helm/hauler -n hauler-system -f values.yaml
 #### via GitHub Container Registry
 
 ```bash
-helm upgrade -i hauler oci://ghcr.io/hauler-dev/charts/hauler -n hauler-system -f values.yaml
+helm upgrade -i hauler oci://ghcr.io/hauler-dev/hauler-helm -n hauler-system -f values.yaml
 ```
 
 #### via DockerHub Container Registry
 
 ```bash
-helm upgrade -i hauler oci://docker.io/hauler/charts/hauler -n hauler-system -f values.yaml
+helm upgrade -i hauler oci://docker.io/hauler/hauler-helm -n hauler-system -f values.yaml
 ```
 
 ## Helm Chart Deployment Status

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.6`       | `1.0.6`     |
+| application | `1.0.7`       | `1.0.7`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.0.7`       | `1.0.7`     |
+| application | `1.0.8`       | `1.0.8`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -18,13 +18,11 @@ spec:
         app: hauler-fileserver
         {{- include "hauler.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or .Values.haulerJobs.hauls.enabled .Values.haulerJobs.manifests.enabled }}
+    {{- if and (or .Values.haulerJobs.remote .Values.haulerJobs.local) (or (and .Values.haulerJobs.local .Values.haulerJobs.local.path) (and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0)) (and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0))  (and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0))  ) }}
       initContainers:
-        {{- if .Values.haulerJobs.hauls.enabled }}
-        - name: wait-for-hauler-hauls-job
-          image: {{ .Values.hauler.initContainers.image.repository }}:{{ .Values.hauler.initContainers.image.tag }}
+        - name: wait-for-hauler-loader
           imagePullPolicy: {{ .Values.hauler.initContainers.imagePullPolicy }}
-          args: ["wait", "--for=condition=complete", "job", "hauler-hauls-job", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
+          args: ["wait", "--for=condition=complete", "job", "hauler-loader", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -33,21 +31,6 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-        {{- end }}
-        {{- if .Values.haulerJobs.manifests.enabled }}
-        - name: wait-for-hauler-manifests-job
-          image: {{ .Values.hauler.initContainers.image.repository }}:{{ .Values.hauler.initContainers.image.tag }}
-          imagePullPolicy: {{ .Values.hauler.initContainers.imagePullPolicy }}
-          args: ["wait", "--for=condition=complete", "job", "hauler-manifests-job", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
-        {{- end }}
       {{- end }}
       containers:
         - name: hauler-fileserver

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -48,6 +48,20 @@ spec:
             seccompProfile:
               type: RuntimeDefault
         {{- end }}
+        {{- if .Values.haulerJobs.localhauls.enabled }}
+        - name: wait-for-hauler-localhauls-job
+          image: {{ .Values.hauler.initContainers.image.repository }}:{{ .Values.hauler.initContainers.image.tag }}
+          imagePullPolicy: {{ .Values.hauler.initContainers.imagePullPolicy }}
+          args: ["wait", "--for=condition=complete", "job", "hauler-localhauls-job", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+        {{- end }}
       {{- end }}
       containers:
         - name: hauler-registry

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -18,13 +18,11 @@ spec:
         app: hauler-registry
         {{- include "hauler.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or .Values.haulerJobs.hauls.enabled .Values.haulerJobs.manifests.enabled .Values.haulerJobs.localhauls.enabled }}
+    {{- if and (or .Values.haulerJobs.remote .Values.haulerJobs.local) (or (and .Values.haulerJobs.local .Values.haulerJobs.local.path) (and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0)) (and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0))  (and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0))  ) }}
       initContainers:
-        {{- if .Values.haulerJobs.hauls.enabled }}
-        - name: wait-for-hauler-hauls-job
-          image: {{ .Values.hauler.initContainers.image.repository }}:{{ .Values.hauler.initContainers.image.tag }}
+        - name: wait-for-hauler-loader
           imagePullPolicy: {{ .Values.hauler.initContainers.imagePullPolicy }}
-          args: ["wait", "--for=condition=complete", "job", "hauler-hauls-job", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
+          args: ["wait", "--for=condition=complete", "job", "hauler-loader", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -33,35 +31,6 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-        {{- end }}
-        {{- if .Values.haulerJobs.manifests.enabled }}
-        - name: wait-for-hauler-manifests-job
-          image: {{ .Values.hauler.initContainers.image.repository }}:{{ .Values.hauler.initContainers.image.tag }}
-          imagePullPolicy: {{ .Values.hauler.initContainers.imagePullPolicy }}
-          args: ["wait", "--for=condition=complete", "job", "hauler-manifests-job", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
-        {{- end }}
-        {{- if .Values.haulerJobs.localhauls.enabled }}
-        - name: wait-for-hauler-localhauls-job
-          image: {{ .Values.hauler.initContainers.image.repository }}:{{ .Values.hauler.initContainers.image.tag }}
-          imagePullPolicy: {{ .Values.hauler.initContainers.imagePullPolicy }}
-          args: ["wait", "--for=condition=complete", "job", "hauler-localhauls-job", "--namespace", "{{ .Release.Namespace }}", "--timeout={{ .Values.hauler.initContainers.timeout }}"]
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
-        {{- end }}
       {{- end }}
       containers:
         - name: hauler-registry

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: hauler-registry
         {{- include "hauler.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or .Values.haulerJobs.hauls.enabled .Values.haulerJobs.manifests.enabled }}
+      {{- if or .Values.haulerJobs.hauls.enabled .Values.haulerJobs.manifests.enabled .Values.haulerJobs.localhauls.enabled }}
       initContainers:
         {{- if .Values.haulerJobs.hauls.enabled }}
         - name: wait-for-hauler-hauls-job

--- a/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
@@ -4,8 +4,8 @@ kind: Ingress
 metadata:
   annotations:
     annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{- range $key, $value := .Values.haulerRegistry.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   name: hauler-registry
   namespace: {{ .Release.Namespace }}

--- a/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
@@ -2,6 +2,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  annotations:
+    annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
   name: hauler-registry
   namespace: {{ .Release.Namespace }}
   labels:

--- a/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    annotations:
     {{- range $key, $value := .Values.haulerRegistry.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -124,3 +124,43 @@ spec:
           persistentVolumeClaim:
             claimName: hauler-data
 {{- end }}
+---
+{{- if .Values.haulerJobs.localhauls.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hauler-localhauls-job
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hauler.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: hauler-fetch-localhauls
+          image: {{ .Values.haulerJobs.image.repository }}:{{ .Values.haulerJobs.image.tag }}
+          imagePullPolicy: {{ .Values.haulerJobs.imagePullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              ls -lha /store &&
+              cp -r /hauls/* /store/ &&
+              chown -R 1001:1001 /store &&
+              ls -lha /store &&
+              echo hauler fetch completed
+          volumeMounts:
+            - name: hauler-data
+              mountPath: /store
+            - name: host-data
+              mountPath: /hauls
+          securityContext:
+            runAsUser: 0
+      restartPolicy: OnFailure
+      volumes:
+        - name: hauler-data
+          persistentVolumeClaim:
+            claimName: hauler-data
+        - name: host-data
+          hostPath:
+            path: {{ .Valuus.haulerJobs.localhauls.hostPath }}
+{{- end }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -162,5 +162,5 @@ spec:
             claimName: hauler-data
         - name: host-data
           hostPath:
-            path: {{ .Valuus.haulerJobs.localhauls.hostPath }}
+            path: {{ .Values.haulerJobs.localhauls.hostPath }}
 {{- end }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -144,17 +144,15 @@ spec:
           args:
             - |
             {{- if .Values.haulerJobs.localhauls.storePath }}
-              ls -lha /stores /store    &&
+              ls -lha /stores           &&
               cp -r /stores/* /store/   &&
               chown -R 1001:1001 /store &&
-              ls -lha /store &&
               echo hauler whole-store load completed
             {{- end }}
             {{- if .Values.haulerJobs.localhauls.haulFiles }}
-              ls -lha /store /haulfiles &&
-              USER=hauler hauler store load -s /store /haulfiles/*  &&
+              ls -lha /haulfiles/*.zst  &&
+              USER=hauler hauler store load -s /store /haulfiles/*.zst  --ignore-errors &&
               chown -R 1001:1001 /store &&
-              ls -lha /store &&
               echo hauler haul file load completed
             {{- end }}
           volumeMounts:

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.haulerJobs.hauls.enabled }}
+{{- if and (or .Values.haulerJobs.remote .Values.haulerJobs.local) (or (and .Values.haulerJobs.local .Values.haulerJobs.local.path) (and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0)) (and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0))  (and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0))  ) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hauler-hauls-job
+  name: hauler-loader
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "hauler.labels" . | nindent 4 }}
@@ -10,104 +10,62 @@ spec:
   template:
     spec:
       initContainers:
-        - name: hauler-fetch-hauls
+        - name: hauler-fetch
           image: {{ .Values.haulerJobs.image.repository }}:{{ .Values.haulerJobs.image.tag }}
           imagePullPolicy: {{ .Values.haulerJobs.imagePullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
             - |
-              {{- range .Values.haulerJobs.hauls.artifacts }}
-              curl -o /hauls/{{ .name }} {{ .path }} &&
+              {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.store }}
+              cp -vr /local-store/* /store/   &&
+              chown -R 1001:1001 /store &&
               {{- end }}
-              echo hauler fetch completed
-          volumeMounts:
-            - name: hauler-data
-              mountPath: /hauls
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
-      containers:
-        - name: hauler-load-hauls
-          image: {{ .Values.hauler.image.repository }}:{{ .Values.hauler.image.tag }}
-          imagePullPolicy: {{ .Values.hauler.imagePullPolicy }}
-          args:
-            - "store"
-            - "load"
-            {{- range .Values.haulerJobs.hauls.artifacts }}
-            - "/hauls/{{ .name }}"
-            {{- end }}
-          volumeMounts:
-            - name: hauler-data
-              mountPath: /hauls
-            - name: hauler-data
-              mountPath: /store
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
-      restartPolicy: OnFailure
-      volumes:
-        - name: hauler-data
-          persistentVolumeClaim:
-            claimName: hauler-data
-{{- end }}
----
-{{- if .Values.haulerJobs.manifests.enabled }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: hauler-manifests-job
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "hauler.labels" . | nindent 4 }}
-spec:
-  template:
-    spec:
-      initContainers:
-        - name: hauler-fetch-manifests
-          image: {{ .Values.haulerJobs.image.repository }}:{{ .Values.haulerJobs.image.tag }}
-          imagePullPolicy: {{ .Values.haulerJobs.imagePullPolicy }}
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              {{- range .Values.haulerJobs.manifests.artifacts }}
+              {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts }}
+              {{- range .Values.haulerJobs.local.artifacts }}
+              cp -v /tmp/local-artifact-{{ .name }} /artifacts/ &&
+              {{- end}}
+              {{- end}}
+              {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.manifests }}
+              {{- range .Values.haulerJobs.local.manifests }}
+              cp -v /tmp/local-manifest-{{ .name }} /manifests/ &&
+              {{- end}}
+              {{- end}}
+              {{- if and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts }}
+              {{- range .Values.haulerJobs.remote.artifacts }}
+              curl -o /artifacts/{{ .name }} {{ .path }} &&
+              {{- end }}
+              {{- end }}
+              {{- if and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests }}
+              {{- range .Values.haulerJobs.remote.manifests }}
               curl -o /manifests/{{ .name }} {{ .path }} &&
               {{- end }}
+              {{- end }}
               echo hauler fetch completed
           volumeMounts:
-            - name: hauler-data
-              mountPath: /manifests
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
-      containers:
-        - name: hauler-load-manifests
-          image: {{ .Values.hauler.image.repository }}:{{ .Values.hauler.image.tag }}
-          imagePullPolicy: {{ .Values.hauler.imagePullPolicy }}
-          args:
-            {{- range .Values.haulerJobs.manifests.artifacts }}
-            - "store"
-            - "sync"
-            - "--files"
-            - "/manifests/{{ .name }}"
+            {{- if or (and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0)) }}
+            - name: artifact-data
+              mountPath: /artifacts
             {{- end }}
-          volumeMounts:
-            - name: hauler-data
+            {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0) }}
+            {{- range .Values.haulerJobs.local.artifacts }}
+            - name: local-artifact-{{ .name }}
+              mountPath: /tmp/local-artifact-{{ .name }}
+            {{- end }}
+            {{- end }}
+            {{- if or (and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0)) }}
+            - name: manifest-data
               mountPath: /manifests
+            {{- end }}
+            {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0) }}
+            {{- range .Values.haulerJobs.local.manifests }}
+            - name: local-manifest-{{ .name }}
+              mountPath: /tmp/local-manifest-{{ .name }}
+            {{- end }}
+            {{- end }}
+            {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.store }}
+            - name: store-data
+              mountPath: /local-store
+            {{- end }}
             - name: hauler-data
               mountPath: /store
           securityContext:
@@ -118,69 +76,87 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-      restartPolicy: OnFailure
-      volumes:
-        - name: hauler-data
-          persistentVolumeClaim:
-            claimName: hauler-data
-{{- end }}
----
-{{- if .Values.haulerJobs.localhauls.enabled }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: hauler-localhauls-job
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "hauler.labels" . | nindent 4 }}
-spec:
-  template:
-    spec:
       containers:
-        - name: hauler-fetch-localhauls
-          image: {{ .Values.haulerJobs.image.repository }}:{{ .Values.haulerJobs.image.tag }}
-          imagePullPolicy: {{ .Values.haulerJobs.imagePullPolicy }}
+        - name: hauler-load
+          image: {{ .Values.hauler.image.repository }}:{{ .Values.hauler.image.tag }}
+          imagePullPolicy: {{ .Values.hauler.imagePullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
             - |
-            {{- if .Values.haulerJobs.localhauls.storePath }}
-              ls -lha /stores           &&
-              cp -r /stores/* /store/   &&
-              chown -R 1001:1001 /store &&
-              echo hauler whole-store load completed
+            {{- if and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0) }}
+            {{- range .Values.haulerJobs.remote.artifacts }}
+              hauler store load /artifacts/{{ .name }} &&
             {{- end }}
-            {{- if .Values.haulerJobs.localhauls.haulFiles }}
-              ls -lha /haulfiles/*.zst  &&
-              USER=hauler hauler store load -s /store /haulfiles/*.zst  --ignore-errors &&
-              chown -R 1001:1001 /store &&
-              echo hauler haul file load completed
             {{- end }}
+            {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0) }}
+            {{- range .Values.haulerJobs.local.artifacts }}
+              hauler store load /artifacts/{{ .name }} &&
+            {{- end }}
+            {{- end }}
+            {{- if and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0) }}
+            {{- range .Values.haulerJobs.remote.manifests }}
+              hauler store sync --files /manifests/{{ .name }} &&
+            {{- end }}
+            {{- end }}
+            {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0) }}
+            {{- range .Values.haulerJobs.local.manifests }}
+              hauler store sync --files /manifests/{{ .name }} &&
+            {{- end }}
+            {{- end }}
+              echo hauler load completed
           volumeMounts:
+            {{- if and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0) }}
+            - name: artifact-data
+              mountPath: /artifacts
+            {{- end }}
+            {{- if and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0) }}
+            - name: manifest-data
+              mountPath: /manifests
+            {{- end }}
+            {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.store }}
+            - name: store-data
+              mountPath: /local-store
+            {{- end }}
             - name: hauler-data
               mountPath: /store
-            {{- if .Values.haulerJobs.localhauls.storePath }}
-            - name: store-data
-              mountPath: /stores
-            {{- end }}
-            {{- if .Values.haulerJobs.localhauls.haulFiles }}
-            - name: haul-files
-              mountPath: /haulfiles
-            {{- end }}
           securityContext:
-            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
       restartPolicy: OnFailure
       volumes:
+        {{- if or (and .Values.haulerJobs.remote .Values.haulerJobs.remote.artifacts (gt (len .Values.haulerJobs.remote.artifacts) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0)) }}
+        - name: artifact-data
+          emptyDir:
+        {{- end }}
+        {{- if (and .Values.haulerJobs.local .Values.haulerJobs.local.artifacts (gt (len .Values.haulerJobs.local.artifacts) 0)) }}
+        {{- range .Values.haulerJobs.local.artifacts }}
+        - name: local-artifact-{{ .name }}
+          hostPath: 
+            path: {{ .path }}
+        {{- end }}
+        {{- end }}
+        {{- if or (and .Values.haulerJobs.remote .Values.haulerJobs.remote.manifests (gt (len .Values.haulerJobs.remote.manifests) 0)) (and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0)) }}
+        - name: manifest-data
+          emptyDir:
+        {{- end }}
+        {{- if (and .Values.haulerJobs.local .Values.haulerJobs.local.manifests (gt (len .Values.haulerJobs.local.manifests) 0)) }}
+        {{- range .Values.haulerJobs.local.manifests }}
+        - name: local-manifest-{{ .name }}
+          hostPath: 
+            path: {{ .path }}
+        {{- end }}
+        {{- end }}
+        {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.store }}
+        - name: store-data
+          hostPath:
+            path: {{ .Values.haulerJobs.local.store }}
+        {{- end }}
         - name: hauler-data
           persistentVolumeClaim:
             claimName: hauler-data
-        {{- if .Values.haulerJobs.localhauls.storePath }}
-        - name: store-data
-          hostPath:
-            path: {{ .Values.haulerJobs.localhauls.storePath }}
-        {{- end }}
-        {{- if .Values.haulerJobs.localhauls.haulFiles }}
-        - name: haul-files
-          hostPath:
-            path: {{ .Values.haulerJobs.localhauls.haulFiles }}
-        {{- end }}
 {{- end }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -143,11 +143,20 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+            {{- if .Values.haulerJobs.localhauls.storePath }}
               ls -lha /store &&
               cp -r /hauls/* /store/ &&
               chown -R 1001:1001 /store &&
               ls -lha /store &&
-              echo hauler fetch completed
+              echo hauler whole-store load completed
+            {{- end }}
+            {{- if .Values.haulerJobs.localhauls.haulFiles }}
+              ls -lha /store &&
+              USER=hauler hauler store load -s /store {{ .Values.haulerJobs.localhauls.haulFiles }}
+              chown -R 1001:1001 /store &&
+              ls -lha /store &&
+              echo hauler haul file load completed
+            {{- end }}
           volumeMounts:
             - name: hauler-data
               mountPath: /store
@@ -162,5 +171,7 @@ spec:
             claimName: hauler-data
         - name: host-data
           hostPath:
-            path: {{ .Values.haulerJobs.localhauls.hostPath }}
+            {{- if .Values.haulerJobs.localhauls.storePath }}
+            path: {{ .Values.haulerJobs.localhauls.storePath }}
+            {{- end }}
 {{- end }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -144,15 +144,15 @@ spec:
           args:
             - |
             {{- if .Values.haulerJobs.localhauls.storePath }}
-              ls -lha /store &&
-              cp -r /hauls/* /store/ &&
+              ls -lha /stores /store    &&
+              cp -r /stores/* /store/   &&
               chown -R 1001:1001 /store &&
               ls -lha /store &&
               echo hauler whole-store load completed
             {{- end }}
             {{- if .Values.haulerJobs.localhauls.haulFiles }}
-              ls -lha /store &&
-              USER=hauler hauler store load -s /store {{ .Values.haulerJobs.localhauls.haulFiles }}
+              ls -lha /store /haulfiles &&
+              USER=hauler hauler store load -s /store /haulfiles/*  &&
               chown -R 1001:1001 /store &&
               ls -lha /store &&
               echo hauler haul file load completed
@@ -160,8 +160,14 @@ spec:
           volumeMounts:
             - name: hauler-data
               mountPath: /store
-            - name: host-data
-              mountPath: /hauls
+            {{- if .Values.haulerJobs.localhauls.storePath }}
+            - name: store-data
+              mountPath: /stores
+            {{- end }}
+            {{- if .Values.haulerJobs.localhauls.haulFiles }}
+            - name: haul-files
+              mountPath: /haulfiles
+            {{- end }}
           securityContext:
             runAsUser: 0
       restartPolicy: OnFailure
@@ -169,9 +175,14 @@ spec:
         - name: hauler-data
           persistentVolumeClaim:
             claimName: hauler-data
-        - name: host-data
+        {{- if .Values.haulerJobs.localhauls.storePath }}
+        - name: store-data
           hostPath:
-            {{- if .Values.haulerJobs.localhauls.storePath }}
             path: {{ .Values.haulerJobs.localhauls.storePath }}
-            {{- end }}
+        {{- end }}
+        {{- if .Values.haulerJobs.localhauls.haulFiles }}
+        - name: haul-files
+          hostPath:
+            path: {{ .Values.haulerJobs.localhauls.haulFiles }}
+        {{- end }}
 {{- end }}

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -4,13 +4,13 @@
 hauler:
   image:
     repository: hauler/hauler
-    tag: 1.1.0
+    tag: 1.1.1
   imagePullPolicy: Always
 
   initContainers:
     image:
       repository: rancher/kubectl
-      tag: v1.29.0 # update to your kubernetes version
+      tag: v1.31.3 # update to your kubernetes version
     imagePullPolicy: Always
     timeout: 1h
 
@@ -26,7 +26,7 @@ hauler:
 haulerJobs:
   image:
     repository: hauler/hauler-debug
-    tag: 1.1.0
+    tag: 1.1.1
   imagePullPolicy: Always
 
   hauls:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -4,7 +4,7 @@
 hauler:
   image:
     repository: hauler/hauler
-    tag: v1.1.0
+    tag: 1.1.0
   imagePullPolicy: Always
 
   initContainers:
@@ -26,7 +26,7 @@ hauler:
 haulerJobs:
   image:
     repository: hauler/hauler-debug
-    tag: v1.1.0
+    tag: 1.1.0
   imagePullPolicy: Always
 
   hauls:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -3,8 +3,8 @@
 
 hauler:
   image:
-    repository: ghcr.io/hauler-dev/hauler
-    tag: v1.0.6
+    repository: hauler/hauler
+    tag: v1.0.7
   imagePullPolicy: Always
 
   initContainers:
@@ -17,7 +17,7 @@ hauler:
   data:
     pvc:
       accessModes: ReadWriteMany
-      storageClass: longhorn # optional... will use default storage class
+      # storageClass: longhorn # optional... will use default storage class
       storageRequest: 48Gi # recommended size of 3x the artifact(s)
 
 # Helm Chart Values for the Hauler Jobs
@@ -25,8 +25,8 @@ hauler:
 
 haulerJobs:
   image:
-    repository: ghcr.io/hauler-dev/hauler-debug
-    tag: v1.0.6
+    repository: hauler/hauler-debug
+    tag: v1.0.7
   imagePullPolicy: Always
 
   hauls:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -4,7 +4,7 @@
 hauler:
   image:
     repository: ghcr.io/hauler-dev/hauler
-    tag: v1.0.4
+    tag: v1.0.6
   imagePullPolicy: Always
 
   initContainers:
@@ -25,8 +25,8 @@ hauler:
 
 haulerJobs:
   image:
-    repository: rancher/shell
-    tag: v0.1.24
+    repository: ghcr.io/hauler-dev/hauler-debug
+    tag: v1.0.6
   imagePullPolicy: Always
 
   hauls:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -4,13 +4,13 @@
 hauler:
   image:
     repository: hauler/hauler
-    tag: v1.0.8
+    tag: v1.1.0
   imagePullPolicy: Always
 
   initContainers:
     image:
       repository: rancher/kubectl
-      tag: v1.28.0 # update to your kubernetes version
+      tag: v1.29.0 # update to your kubernetes version
     imagePullPolicy: Always
     timeout: 1h
 
@@ -26,7 +26,7 @@ hauler:
 haulerJobs:
   image:
     repository: hauler/hauler-debug
-    tag: v1.0.8
+    tag: v1.1.0
   imagePullPolicy: Always
 
   hauls:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -4,7 +4,7 @@
 hauler:
   image:
     repository: hauler/hauler
-    tag: v1.0.7
+    tag: v1.0.8
   imagePullPolicy: Always
 
   initContainers:
@@ -26,7 +26,7 @@ hauler:
 haulerJobs:
   image:
     repository: hauler/hauler-debug
-    tag: v1.0.7
+    tag: v1.0.8
   imagePullPolicy: Always
 
   hauls:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -46,11 +46,14 @@ haulerJobs:
       #   name: additional-manifests.yaml
       #
 
-  # use this when copying hauls in directly to a host - storePath is the "-s" argument to hauler store OR haulFiles is the "hauls" directory to load in
+  # use this when copying haulfiles or stores in directly to a host
+  # storePath is the "-s" argument to hauler store
+  # haulFiles is the "hauls" directory (containing zst files) to load
+  # at least one of storePath or haulFiles must be populated, using both will copy in the store then load the haul files
   localhauls:
     enabled: false
-    storePath: /my/previously/created/hauler/store/dir/
-    haulFiles: /haul/files/to/load/dir/
+    #storePath: /my/previously/created/hauler/store/dir/  # leave commented out if unused
+    #haulFiles: /haul/files/to/load/dir/                  # leave commented out if unused
 
 # Helm Chart Values for the Hauler Fileserver
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/guides-references/command-line/hauler-store#hauler-store-serve-fileserver

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -4,7 +4,7 @@
 hauler:
   image:
     repository: hauler/hauler
-    tag: 1.1.1
+    tag: 1.2.0
   imagePullPolicy: Always
 
   initContainers:
@@ -22,42 +22,46 @@ hauler:
 
 # Helm Chart Values for the Hauler Jobs
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/introduction/quickstart
+# Hauler Jobs are used to populate the Registry and/or Filestore with content
+# Use "local" in order to populate the hauler store with locally available stores, artifacts, and/or manifests.
+# Use "remote" if these are remotely (HTTP/S/FTP/etc) available instead
+# Simply comment out any unneeded values
 
 haulerJobs:
   image:
     repository: hauler/hauler-debug
-    tag: 1.1.1
+    tag: 1.2.0
   imagePullPolicy: Always
-
-  hauls:
-    enabled: true
+  # "remote" refers to URL-based hauler artifacts and/or manifests
+  remote:
     artifacts:
       - path: https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/haul.tar.zst
+        name: remhaul.tar.zst
+      # - path: /path/to/additional-hauls.tar.zst
+      #   name: additional-hauls.tar.zst
+    manifests:
+      - path: https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/hauler-manifest.yaml
+        name: remhauler-manifest.yaml
+      # - path: /path/to/additional-manifests.yaml
+      #   name: additional-manifests.yaml
+  # "local" refers to the host the container/kubectl is being run on.  Use filesystem paths (hostDir) for these values.
+  local:
+    artifacts:
+      - path: /usr/local/testdata/haul.tar.zst
         name: haul.tar.zst
       # - path: /path/to/additional-hauls.tar.zst
       #   name: additional-hauls.tar.zst
-
-  manifests:
-    enabled: true
-    artifacts:
-      - path: https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/hauler-manifest.yaml
+    manifests:
+      - path: /usr/local/testdata/hauler-manifest.yaml
         name: hauler-manifest.yaml
       # - path: /path/to/additional-manifests.yaml
       #   name: additional-manifests.yaml
-      #
-
-  # use this when copying haulfiles or stores in directly to a host
-  # storePath is the "-s" argument to hauler store
-  # haulFiles is the "hauls" directory (containing zst files) to load
-  # at least one of storePath or haulFiles must be populated, using both will copy in the store then load the haul files
-  localhauls:
-    enabled: false
-    #storePath: /my/previously/created/hauler/store/dir/  # leave commented out if unused
-    #haulFiles: /haul/files/to/load/dir/                  # leave commented out if unused
+    # "store" refers to a previously created hauler folder structure.  See the "-s" argument to hauler.  Only one path is acceptable
+    store: /my/previously/created/hauler/store/dir/
 
 # Helm Chart Values for the Hauler Fileserver
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/guides-references/command-line/hauler-store#hauler-store-serve-fileserver
-
+#
 haulerFileserver:
   enabled: true
   port: 8080 # default port for the fileserver

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -46,11 +46,11 @@ haulerJobs:
       #   name: additional-manifests.yaml
       #
 
-  # use this when copying hauls in directly to a host - storePath is the "-s" argument to hauler store OR haulFiles is the "hauls" to load in
+  # use this when copying hauls in directly to a host - storePath is the "-s" argument to hauler store OR haulFiles is the "hauls" directory to load in
   localhauls:
     enabled: false
     storePath: /my/previously/created/hauler/store/dir/
-    haulFiles: /haul/files/to/load.*.tgz
+    haulFiles: /haul/files/to/load/dir/
 
 # Helm Chart Values for the Hauler Fileserver
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/guides-references/command-line/hauler-store#hauler-store-serve-fileserver

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -45,8 +45,10 @@ haulerJobs:
       # - path: /path/to/additional-manifests.yaml
       #   name: additional-manifests.yaml
       #
+
+  # use this when copying hauls in directly to a host - hostPath is the "-s" argument to hauler store
   localhauls:
-    enabled: true
+    enabled: false
     hostPath: /usr/local/registry
 
 # Helm Chart Values for the Hauler Fileserver

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -44,6 +44,10 @@ haulerJobs:
         name: hauler-manifest.yaml
       # - path: /path/to/additional-manifests.yaml
       #   name: additional-manifests.yaml
+      #
+  localhauls:
+    enabled: true
+    hostPath: /usr/local/registry
 
 # Helm Chart Values for the Hauler Fileserver
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/guides-references/command-line/hauler-store#hauler-store-serve-fileserver

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -46,10 +46,11 @@ haulerJobs:
       #   name: additional-manifests.yaml
       #
 
-  # use this when copying hauls in directly to a host - hostPath is the "-s" argument to hauler store
+  # use this when copying hauls in directly to a host - storePath is the "-s" argument to hauler store OR haulFiles is the "hauls" to load in
   localhauls:
     enabled: false
-    hostPath: /usr/local/registry
+    storePath: /my/previously/created/hauler/store/dir/
+    haulFiles: /haul/files/to/load.*.tgz
 
 # Helm Chart Values for the Hauler Fileserver
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/guides-references/command-line/hauler-store#hauler-store-serve-fileserver


### PR DESCRIPTION
Adds "localhaul" to the chart as an enable-able job.  Copies files in directly (like when webservers aren't available for curl to use).