### PR TITLE
updates for `v1.2.0`

### DIFF
--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -3,5 +3,5 @@ name: hauler-helm
 description: Hauler Helm Chart - Airgap Swiss Army Knife
 icon: https://raw.githubusercontent.com/hauler-dev/hauler/main/static/rgs-hauler-logo-icon.svg
 type: application
-version: 1.1.1
-appVersion: 1.1.1
+version: 1.2.0
+appVersion: 1.2.0

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.1.1`       | `1.1.1`     |
+| application | `1.2.0`       | `1.2.0`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -1,10 +1,8 @@
 # Hauler Helm Chart
 
----
-
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `1.1.1`       | `1.1.1`     |
+| application | `1.2.0`       | `1.2.0`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/templates/hauler/hauler-debug.yaml
+++ b/charts/hauler/templates/hauler/hauler-debug.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.debug.enabled }}
+{{- if .Values.hauler.debug.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,10 +21,10 @@ spec:
     spec:
       containers:
         - name: hauler-debug
-          image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}
-          imagePullPolicy: {{ .Values.debug.imagePullPolicy }}
-          command: {{ .Values.debug.command }}
-          args: {{ .Values.debug.args }}
+          image: {{ .Values.hauler.debug.image.repository }}:{{ .Values.hauler.debug.image.tag }}
+          imagePullPolicy: {{ .Values.hauler.debug.imagePullPolicy }}
+          command: {{ .Values.hauler.debug.command }}
+          args: {{ .Values.hauler.debug.args }}
           volumeMounts:
             - name: hauler-data
               mountPath: /store

--- a/charts/hauler/templates/hauler/hauler-debug.yaml
+++ b/charts/hauler/templates/hauler/hauler-debug.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.debug.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hauler-debug
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: hauler-debug
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hauler-debug
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hauler-debug
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: hauler-debug
+          image: {{ .Values.debug.image.repository }}:{{ .Values.debug.image.tag }}
+          imagePullPolicy: {{ .Values.debug.imagePullPolicy }}
+          command: {{ .Values.debug.command }}
+          args: {{ .Values.debug.args }}
+          volumeMounts:
+            - name: hauler-data
+              mountPath: /store
+            - name: hauler-hauls
+              mountPath: /hauls
+            - name: hauler-manifests
+              mountPath: /manifests
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+      restartPolicy: Always
+      volumes:
+        - name: hauler-data
+          persistentVolumeClaim:
+            claimName: hauler-data
+        - name: hauler-hauls
+          persistentVolumeClaim:
+            claimName: hauler-hauls
+        - name: hauler-manifests
+          persistentVolumeClaim:
+            claimName: hauler-manifests
+{{- end }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -16,28 +16,6 @@ metadata:
 spec:
   template:
     spec:
-      initContainers:
-        - name: hauler-fetch-hauls
-          image: {{ .Values.haulerJobs.image.repository }}:{{ .Values.haulerJobs.image.tag }}
-          imagePullPolicy: {{ .Values.haulerJobs.imagePullPolicy }}
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              {{- range .Values.haulerJobs.hauls.artifacts }}
-              curl -o /hauls/{{ .name }} {{ .path }} &&
-              {{- end }}
-              echo hauler fetch completed
-          volumeMounts:
-            - name: hauler-data
-              mountPath: /hauls
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
       containers:
         - name: hauler-load-hauls
           image: {{ .Values.hauler.image.repository }}:{{ .Values.hauler.image.tag }}
@@ -45,8 +23,9 @@ spec:
           args:
             - "store"
             - "load"
+            - "--filename"
             {{- range .Values.haulerJobs.hauls.artifacts }}
-            - "/hauls/{{ .name }}"
+            - "{{ .path }}"
             {{- end }}
           volumeMounts:
             - name: hauler-data
@@ -86,28 +65,6 @@ metadata:
 spec:
   template:
     spec:
-      initContainers:
-        - name: hauler-fetch-manifests
-          image: {{ .Values.haulerJobs.image.repository }}:{{ .Values.haulerJobs.image.tag }}
-          imagePullPolicy: {{ .Values.haulerJobs.imagePullPolicy }}
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              {{- range .Values.haulerJobs.manifests.artifacts }}
-              curl -o /manifests/{{ .name }} {{ .path }} &&
-              {{- end }}
-              echo hauler fetch completed
-          volumeMounts:
-            - name: hauler-data
-              mountPath: /manifests
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 1001
-            seccompProfile:
-              type: RuntimeDefault
       containers:
         - name: hauler-load-manifests
           image: {{ .Values.hauler.image.repository }}:{{ .Values.hauler.image.tag }}
@@ -116,8 +73,8 @@ spec:
             {{- range .Values.haulerJobs.manifests.artifacts }}
             - "store"
             - "sync"
-            - "--files"
-            - "/manifests/{{ .name }}"
+            - "--filename"
+            - "{{ .path }}"
             {{- end }}
           volumeMounts:
             - name: hauler-data

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -25,6 +25,15 @@ hauler:
       # storageClass: longhorn # optional... will use default storage class
       storageRequest: 48Gi # recommended size of 3x the artifact(s)
 
+  debug:
+    enabled: false
+    image:
+      repository: hauler/hauler-debug
+      tag: 1.2.0
+    imagePullPolicy: Always
+    command: ["/bin/sh"]
+    args: ["-c", "sleep infinity"]
+
 # Helm Chart Values for the Hauler Jobs
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/introduction/quickstart
 

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -26,7 +26,7 @@ hauler:
       storageRequest: 48Gi # recommended size of 3x the artifact(s)
 
   debug:
-    enabled: false
+    enabled: true
     image:
       repository: hauler/hauler-debug
       tag: 1.2.0

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -29,11 +29,6 @@ hauler:
 # Docs: https://rancherfederal.github.io/hauler-docs/docs/introduction/quickstart
 
 haulerJobs:
-  image:
-    repository: hauler/hauler-debug
-    tag: 1.2.0
-  imagePullPolicy: Always
-
   hauls:
     enabled: true
     artifacts:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -9,7 +9,7 @@ hauler:
 
   image:
     repository: hauler/hauler
-    tag: 1.1.1
+    tag: 1.2.0
   imagePullPolicy: Always
 
   initContainers:
@@ -31,7 +31,7 @@ hauler:
 haulerJobs:
   image:
     repository: hauler/hauler-debug
-    tag: 1.1.1
+    tag: 1.2.0
   imagePullPolicy: Always
 
   hauls:


### PR DESCRIPTION
depends on updating `docs` references in `values.yaml` after releasing the `v1.2.0` release of https://github.com/hauler-dev/hauler-docs...

### helm template
```bash
---
# Source: hauler-helm/templates/hauler/hauler-rbac.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: hauler-service-account
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
---
# Source: hauler-helm/templates/hauler/hauler-pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: hauler-data
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 48Gi
---
# Source: hauler-helm/templates/hauler/hauler-rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: hauler-role
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
rules:
- apiGroups: ["batch"]
  resources: ["jobs"]
  verbs: ["get", "list", "watch"]
---
# Source: hauler-helm/templates/hauler/hauler-rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: hauler-role-binding
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
roleRef:
  kind: Role
  name: hauler-role
  apiGroup: rbac.authorization.k8s.io
subjects:
  - kind: ServiceAccount
    name: hauler-service-account
    namespace: default
---
# Source: hauler-helm/templates/hauler-fileserver/hauler-fileserver-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: hauler-fileserver
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  selector:
    app: hauler-fileserver
  ports:
    - name: hauler-fileserver
      protocol: TCP
      port: 8080
      targetPort: 8080
  type: ClusterIP
---
# Source: hauler-helm/templates/hauler-registry/hauler-registry-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: hauler-registry
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  selector:
    app: hauler-registry
  ports:
    - name: hauler-registry
      protocol: TCP
      port: 5000
      targetPort: 5000
  type: ClusterIP
---
# Source: hauler-helm/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hauler-fileserver
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  replicas: 1
  selector:
    matchLabels:
      app: hauler-fileserver
      app.kubernetes.io/name: hauler-helm
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app: hauler-fileserver
        app.kubernetes.io/name: hauler-helm
        app.kubernetes.io/instance: release-name
    spec:
      initContainers:
        - name: wait-for-hauler-hauls-job
          image: rancher/kubectl:v1.31.3
          imagePullPolicy: Always
          args: ["wait", "--for=condition=complete", "job", "hauler-hauls-job", "--namespace", "default", "--timeout=1h"]
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
        - name: wait-for-hauler-manifests-job
          image: rancher/kubectl:v1.31.3
          imagePullPolicy: Always
          args: ["wait", "--for=condition=complete", "job", "hauler-manifests-job", "--namespace", "default", "--timeout=1h"]
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      containers:
        - name: hauler-fileserver
          image: hauler/hauler:1.2.0
          imagePullPolicy: Always
          args: ["store", "serve", "fileserver", "--port", "8080"]
          ports:
            - containerPort: 8080
          volumeMounts:
            - name: hauler-data
              mountPath: /store
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      restartPolicy: Always
      serviceAccountName: hauler-service-account
      volumes:
        - name: hauler-data
          persistentVolumeClaim:
            claimName: hauler-data
---
# Source: hauler-helm/templates/hauler-registry/hauler-registry-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hauler-registry
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  replicas: 1
  selector:
    matchLabels:
      app: hauler-registry
      app.kubernetes.io/name: hauler-helm
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app: hauler-registry
        app.kubernetes.io/name: hauler-helm
        app.kubernetes.io/instance: release-name
    spec:
      initContainers:
        - name: wait-for-hauler-hauls-job
          image: rancher/kubectl:v1.31.3
          imagePullPolicy: Always
          args: ["wait", "--for=condition=complete", "job", "hauler-hauls-job", "--namespace", "default", "--timeout=1h"]
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
        - name: wait-for-hauler-manifests-job
          image: rancher/kubectl:v1.31.3
          imagePullPolicy: Always
          args: ["wait", "--for=condition=complete", "job", "hauler-manifests-job", "--namespace", "default", "--timeout=1h"]
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      containers:
        - name: hauler-registry
          image: hauler/hauler:1.2.0
          imagePullPolicy: Always
          args: ["store", "serve", "registry", "--port", "5000"]
          ports:
            - containerPort: 5000
          volumeMounts:
            - name: hauler-data
              mountPath: /store
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      restartPolicy: Always
      serviceAccountName: hauler-service-account
      volumes:
        - name: hauler-data
          persistentVolumeClaim:
            claimName: hauler-data
---
# Source: hauler-helm/templates/hauler/hauler-debug.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hauler-debug
  namespace: default
  labels:
    app.kubernetes.io/name: hauler-debug
    app.kubernetes.io/instance: release-name
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: hauler-debug
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: hauler-debug
        app.kubernetes.io/instance: release-name
    spec:
      containers:
        - name: hauler-debug
          image: hauler/hauler-debug:1.2.0
          imagePullPolicy: Always
          command: [/bin/sh]
          args: [-c sleep infinity]
          volumeMounts:
            - name: hauler-data
              mountPath: /store
            - name: hauler-hauls
              mountPath: /hauls
            - name: hauler-manifests
              mountPath: /manifests
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      restartPolicy: Always
      volumes:
        - name: hauler-data
          persistentVolumeClaim:
            claimName: hauler-data
        - name: hauler-hauls
          persistentVolumeClaim:
            claimName: hauler-hauls
        - name: hauler-manifests
          persistentVolumeClaim:
            claimName: hauler-manifests
---
# Source: hauler-helm/templates/hauler/hauler-jobs.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: hauler-hauls-job
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  template:
    spec:
      containers:
        - name: hauler-load-hauls
          image: hauler/hauler:1.2.0
          imagePullPolicy: Always
          args:
            - "store"
            - "load"
            - "--filename"
            - "https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/haul.tar.zst"
          volumeMounts:
            - name: hauler-data
              mountPath: /hauls
            - name: hauler-data
              mountPath: /store
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      restartPolicy: OnFailure
      volumes:
        - name: hauler-data
          persistentVolumeClaim:
            claimName: hauler-data
---
# Source: hauler-helm/templates/hauler/hauler-jobs.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: hauler-manifests-job
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  template:
    spec:
      containers:
        - name: hauler-load-manifests
          image: hauler/hauler:1.2.0
          imagePullPolicy: Always
          args:
            - "store"
            - "sync"
            - "--filename"
            - "https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/hauler-manifest.yaml"
          volumeMounts:
            - name: hauler-data
              mountPath: /manifests
            - name: hauler-data
              mountPath: /store
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop: ["ALL"]
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
      restartPolicy: OnFailure
      volumes:
        - name: hauler-data
          persistentVolumeClaim:
            claimName: hauler-data
---
# Source: hauler-helm/templates/hauler-fileserver/hauler-fileserver-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: hauler-fileserver
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  rules:
  - host: fileserver.ranchers.io
    http:
      paths:
      - backend:
          service:
            name: hauler-fileserver
            port:
              number: 8080
        path: /
        pathType: Prefix
---
# Source: hauler-helm/templates/hauler-registry/hauler-registry-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: hauler-registry
  namespace: default
  labels:
    helm.sh/chart: hauler-helm-1.2.0
    app.kubernetes.io/name: hauler-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.2.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  rules:
  - host: registry.ranchers.io
    http:
      paths:
      - backend:
          service:
            name: hauler-registry
            port:
              number: 5000
        path: /
        pathType: Prefix
```