### PR TITLE
Add Configurable Health Check delayStart

### DIFF
--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hauler-helm
-version: 2.0.2
+version: 2.0.3
 appVersion: 1.2.1
 
 type: application

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -62,14 +62,14 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 180
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -62,14 +62,14 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.haulerFileserver.delayStart | default 10 }}
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.haulerFileserver.delayStart | default 10 }}
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -62,14 +62,14 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 180
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -68,8 +68,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /
+              port: {{ .Values.haulerRegistry.port }}
             initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
-            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -62,13 +62,13 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
-              port: {{ .Values.haulerRegistry.port }}
+            initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
             initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -75,6 +75,7 @@ haulerFileserver:
   enabled: true
   port: 8080  # default port for the fileserver
   replicas: 1
+  delayStart: 10  # how long for health checks to wait to start checking
 
   ingress:
     enabled: true
@@ -103,6 +104,7 @@ haulerRegistry:
   enabled: true
   port: 5000  # default port for the registry
   replicas: 1
+  delayStart: 10  # how long for health checks to wait to start checking
 
   ingress:
     enabled: true


### PR DESCRIPTION
For instances where the hauler store is very large, make the initialDelaySeconds field configurable on the Deployment health checks.