### PR TITLE
Add StartupProbes to Fileserver and Registry Deployments

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,6 +76,22 @@ jobs:
             then
               echo
               echo COUNTER = $COUNTER, registries failed to start
+              for testvalue in $(ls charts/hauler/ci/*-values.yaml)
+              do
+                name=$(basename ${testvalue}| rev | cut -c13- | rev)
+                namespace=hauler-${name}
+                echo Logs from NAMESPACE = $namespace
+                for container in hauler-fetch hauler-load
+                do
+                echo $container container in hauler-loader job logs:
+                kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c $container
+                done
+                for container in hauler-fileserver hauler-registry
+                do
+                  echo $container pod logs:
+                  kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}
+                done
+              done
               exit 1
             fi
           done
@@ -83,11 +99,28 @@ jobs:
           echo -n "waiting for fileservers to start"
           while kubectl get po -A -lapp=hauler-fileserver -ojsonpath='{.items[*].status.containerStatuses[*].ready}' | grep -q "false"
           do
-            echo -n . ; sleep 1
+            echo -n . ; sleep 1;
             COUNTER=$((COUNTER+1))
             if [ $COUNTER -gt $MAXWAIT ]
             then
               echo
+              echo COUNTER = $COUNTER, registries failed to start
+              for testvalue in $(ls charts/hauler/ci/*-values.yaml)
+              do
+                name=$(basename ${testvalue}| rev | cut -c13- | rev)
+                namespace=hauler-${name}
+                echo Logs from NAMESPACE = $namespace
+                for container in hauler-fetch hauler-load
+                do
+                echo $container container in hauler-loader job logs:
+                kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c $container
+                done
+                for container in hauler-fileserver hauler-registry
+                do
+                  echo $container pod logs:
+                  kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}
+                done
+              done
               echo COUNTER = $COUNTER, fileservers failed to start
               exit 1
             fi
@@ -128,6 +161,23 @@ jobs:
           if ! [ -z "$failures" ]
           then
             echo there were failures, investigate these tests: $failures
+            echo
+            for testvalue in $(ls charts/hauler/ci/*-values.yaml)
+            do
+              name=$(basename ${testvalue}| rev | cut -c13- | rev)
+              namespace=hauler-${name}
+              echo Logs from NAMESPACE = $namespace
+              for container in hauler-fetch hauler-load
+              do
+              echo $container container in hauler-loader job logs:
+              kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c $container
+              done
+              for container in hauler-fileserver hauler-registry
+              do
+                echo $container pod logs:
+                kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}
+              done
+            done
             exit 1
           else
             echo all tests passed: $successes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,9 @@ name: Lint and Test Workflow
 on:
   workflow_dispatch:
   push:
+  pull_request:
+    branches:
+      - 'main'
 
 jobs:
   test-hauler-helm:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,12 +113,12 @@ jobs:
                 for container in hauler-fetch hauler-load
                 do
                 echo $container container in hauler-loader job logs:
-                kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c $container
+                kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c ${container}  || echo No logs for $namespace / $container
                 done
                 for container in hauler-fileserver hauler-registry
                 do
                   echo $container pod logs:
-                  kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}
+                  kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}  || echo No logs for $namespace / $container
                 done
               done
               echo COUNTER = $COUNTER, fileservers failed to start
@@ -170,12 +170,12 @@ jobs:
               for container in hauler-fetch hauler-load
               do
               echo $container container in hauler-loader job logs:
-              kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c $container
+              kubectl logs --tail=100 -n $namespace -l=batch.kubernetes.io/job-name=hauler-loader -c ${container} || echo No logs for $namespace / $container
               done
               for container in hauler-fileserver hauler-registry
               do
                 echo $container pod logs:
-                kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}
+                kubectl logs --tail=100 -n $namespace -lapp=${container} -c ${container}  || echo No logs for $namespace / $container
               done
             done
             exit 1

--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hauler-helm
-version: 2.0.2
+version: 2.0.3
 appVersion: 1.2.1
 
 type: application

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `2.0.2`       | `1.2.1`     |
+| application | `2.0.3`       | `1.2.1`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -2,7 +2,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `2.0.2`       | `1.2.1`     |
+| application | `2.0.3`       | `1.2.1`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -62,14 +62,14 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 180
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -78,7 +78,7 @@ spec:
               port: {{ .Values.haulerFileserver.port }}
             initialDelaySeconds: 15
             periodSeconds: 15
-            failureThreshold: {{ .Values.haulerFileserver.delayStart | default 10 }}
+            failureThreshold: {{ .Values.haulerFileserver.delayStart | default 0 }}
 
       restartPolicy: Always
       serviceAccountName: hauler-service-account

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -62,14 +62,14 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.haulerFileserver.delayStart | default 10 }}
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.haulerFileserver.delayStart | default 10 }}
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -62,16 +62,23 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: {{ .Values.haulerFileserver.delayStart | default 10 }}
+            initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerFileserver.port }}
-            initialDelaySeconds: {{ .Values.haulerFileserver.delayStart | default 10 }}
+            initialDelaySeconds: 10
             periodSeconds: 15
             failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.haulerFileserver.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: {{ .Values.haulerFileserver.delayStart | default 10 }}
 
       restartPolicy: Always
       serviceAccountName: hauler-service-account

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -62,14 +62,14 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: 5
+            initialDelaySeconds: 180
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -78,7 +78,7 @@ spec:
               port: {{ .Values.haulerRegistry.port }}
             initialDelaySeconds: 15
             periodSeconds: 15
-            failureThreshold: {{ .Values.haulerFileserver.delayStart | default 10 }}
+            failureThreshold: {{ .Values.haulerRegistry.delayStart | default 0 }}
 
       restartPolicy: Always
       serviceAccountName: hauler-service-account

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -62,16 +62,23 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
+            initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
+            initialDelaySeconds: 10
             periodSeconds: 15
             failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.haulerFileserver.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: {{ .Values.haulerFileserver.delayStart | default 10 }}
 
       restartPolicy: Always
       serviceAccountName: hauler-service-account

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -75,7 +75,7 @@ spec:
           startupProbe:
             httpGet:
               path: /
-              port: {{ .Values.haulerFileserver.port }}
+              port: {{ .Values.haulerRegistry.port }}
             initialDelaySeconds: 15
             periodSeconds: 15
             failureThreshold: {{ .Values.haulerFileserver.delayStart | default 10 }}

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -68,8 +68,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /
+              port: {{ .Values.haulerRegistry.port }}
             initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
-            initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5
 

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -62,13 +62,13 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.haulerRegistry.port }}
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /
-              port: {{ .Values.haulerRegistry.port }}
+            initialDelaySeconds: {{ .Values.haulerRegistry.delayStart | default 10 }}
             initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 5

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -75,7 +75,7 @@ haulerFileserver:
   enabled: true
   port: 8080  # default port for the fileserver
   replicas: 1
-  delayStart: 0  # how long for health checks to wait to start checking, in minutes
+  delayStart: 0  # how long for health checks to wait to start checking, 15-second intervals
   ingress:
     enabled: true
     # labels:
@@ -103,7 +103,7 @@ haulerRegistry:
   enabled: true
   port: 5000  # default port for the registry
   replicas: 1
-  delayStart: 0  # how long for health checks to wait to start checking, in minutes
+  delayStart: 0  # how long for health checks to wait to start checking, in 15-second intervals
 
   ingress:
     enabled: true

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -75,8 +75,7 @@ haulerFileserver:
   enabled: true
   port: 8080  # default port for the fileserver
   replicas: 1
-  delayStart: 10  # how long for health checks to wait to start checking
-
+  delayStart: 0  # how long for health checks to wait to start checking, in minutes
   ingress:
     enabled: true
     # labels:
@@ -104,7 +103,7 @@ haulerRegistry:
   enabled: true
   port: 5000  # default port for the registry
   replicas: 1
-  delayStart: 10  # how long for health checks to wait to start checking
+  delayStart: 0  # how long for health checks to wait to start checking, in minutes
 
   ingress:
     enabled: true

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -75,6 +75,7 @@ haulerFileserver:
   enabled: true
   port: 8080  # default port for the fileserver
   replicas: 1
+  delayStart: 10  # how long for health checks to wait to start checking
 
   ingress:
     enabled: true
@@ -103,6 +104,7 @@ haulerRegistry:
   enabled: true
   port: 5000  # default port for the registry
   replicas: 1
+  delayStart: 10  # how long for health checks to wait to start checking
 
   ingress:
     enabled: true


### PR DESCRIPTION
Adds:
  startupProbes to each deployment
  delayStart in "values.yaml" in order to delay the startupProbes (in minutes) for large deployments (defaults to 0)
  a ton of verbosity for the test logfiles in case of a failure

Version bump: 2.0.3