### PR TITLE
Create "Restart" for Hauler Helm

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,19 @@ jobs:
           sleep 1
           done
 
+      - name: Fetch and Prepare Test Files
+        run: |
+        mkdir -pv /tmp/tests/store
+        echo "Download local-haul.tar.zst"
+        curl -o /tmp/tests/local-haul.tar.zst https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/haul.tar.zst
+        echo "Download local-manifest.yaml"
+        curl -o /tmp/tests/local-manifest.yaml https://raw.githubusercontent.com/hauler-dev/hauler-helm/main/charts/hauler/ci/test-manifest2.yaml
+        echo "Download hauler binary"
+        curl -sfL https://get.hauler.dev | HAULER_VERSION=1.2.0 bash
+        echo "Create local store"
+        hauler store -s /tmp/tests/store load --filename /tmp/tests/local-haul.tar.zst
+        echo "Store built in /tmp/tests/store"
+
       - name: Install Test Cases
         run: |
           for testvalue in $(ls charts/hauler/ci/*-values.yaml)
@@ -52,19 +65,6 @@ jobs:
             echo $name - $testvalue
             helm install $name charts/hauler --namespace ${namespace} --values ${testvalue} --create-namespace
           done
-
-      - name: Fetch and Prepare Test Files
-        run: |
-          mkdir -pv /tmp/tests/store
-          echo "Download local-haul.tar.zst"
-          curl -o /tmp/tests/local-haul.tar.zst https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/haul.tar.zst
-          echo "Download local-manifest.yaml"
-          curl -o /tmp/tests/local-manifest.yaml https://raw.githubusercontent.com/hauler-dev/hauler-helm/main/charts/hauler/ci/test-manifest2.yaml
-          echo "Download hauler binary"
-          curl -sfL https://get.hauler.dev | HAULER_VERSION=1.2.0 bash
-          echo "Create local store"
-          hauler store -s /tmp/tests/store load --filename /tmp/tests/local-haul.tar.zst
-          echo "Store built in /tmp/tests/store"
 
       - name: Wait for Resources
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,16 +45,16 @@ jobs:
 
       - name: Fetch and Prepare Test Files
         run: |
-        mkdir -pv /tmp/tests/store
-        echo "Download local-haul.tar.zst"
-        curl -o /tmp/tests/local-haul.tar.zst https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/haul.tar.zst
-        echo "Download local-manifest.yaml"
-        curl -o /tmp/tests/local-manifest.yaml https://raw.githubusercontent.com/hauler-dev/hauler-helm/main/charts/hauler/ci/test-manifest2.yaml
-        echo "Download hauler binary"
-        curl -sfL https://get.hauler.dev | HAULER_VERSION=1.2.0 bash
-        echo "Create local store"
-        hauler store -s /tmp/tests/store load --filename /tmp/tests/local-haul.tar.zst
-        echo "Store built in /tmp/tests/store"
+          mkdir -pv /tmp/tests/store
+          echo "Download local-haul.tar.zst"
+          curl -o /tmp/tests/local-haul.tar.zst https://raw.githubusercontent.com/hauler-dev/hauler/main/testdata/haul.tar.zst
+          echo "Download local-manifest.yaml"
+          curl -o /tmp/tests/local-manifest.yaml https://raw.githubusercontent.com/hauler-dev/hauler-helm/main/charts/hauler/ci/test-manifest2.yaml
+          echo "Download hauler binary"
+          curl -sfL https://get.hauler.dev | HAULER_VERSION=1.2.0 bash
+          echo "Create local store"
+          hauler store -s /tmp/tests/store load --filename /tmp/tests/local-haul.tar.zst
+          echo "Store built in /tmp/tests/store"
 
       - name: Install Test Cases
         run: |

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-deployment.yaml
@@ -15,12 +15,19 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.haulerFileserver.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
   selector:
     matchLabels:
       app: hauler-fileserver
       {{- include "hauler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        autorollout: {{ randAlphaNum 5 | quote }}
       labels:
         app: hauler-fileserver
         {{- include "hauler.selectorLabels" . | nindent 8 }}

--- a/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-deployment.yaml
@@ -15,12 +15,19 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.haulerRegistry.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
   selector:
     matchLabels:
       app: hauler-registry
       {{- include "hauler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        autorollout: {{ randAlphaNum 5 | quote }}
       labels:
         app: hauler-registry
         {{- include "hauler.selectorLabels" . | nindent 8 }}

--- a/charts/hauler/templates/hauler/hauler-jobs.yaml
+++ b/charts/hauler/templates/hauler/hauler-jobs.yaml
@@ -10,6 +10,8 @@ metadata:
 {{ toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
     {{- with .Values.hauler.annotations -}}
 {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -24,6 +26,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              rm -rf /store/*
               {{- if and .Values.haulerJobs.local .Values.haulerJobs.local.store }}
               cp -av /local-store/* /store/   &&
               {{- end }}


### PR DESCRIPTION
This enhancement instructs helm upgrade or install to

a) Delete the files on the PVC
b) Re-run the Hauler Job to rebuild the PVC
c) Kick the deployment(s) instructing them to restart
d) Roll the deployments so they stay available during this process

Fixes #31 

@zackbradys 