### PR TITLE
updates for ingresses

### DIFF
--- a/charts/hauler/Chart.yaml
+++ b/charts/hauler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hauler-helm
-version: 2.2.2
+version: 2.2.3
 appVersion: 1.4.2
 
 type: application

--- a/charts/hauler/README.md
+++ b/charts/hauler/README.md
@@ -4,7 +4,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `2.2.2`       | `1.4.2`     |
+| application | `2.2.3`       | `1.4.2`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/app-readme.md
+++ b/charts/hauler/app-readme.md
@@ -2,7 +2,7 @@
 
 | Type        | Chart Version | App Version |
 | ----------- | ------------- | ----------- |
-| application | `2.2.2`       | `1.4.2`     |
+| application | `2.2.3`       | `1.4.2`     |
 
 ## Installing the Chart
 

--- a/charts/hauler/templates/hauler-fileserver/hauler-fileserver-ingress.yaml
+++ b/charts/hauler/templates/hauler-fileserver/hauler-fileserver-ingress.yaml
@@ -20,6 +20,9 @@ metadata:
 {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.haulerFileserver.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.haulerFileserver.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.haulerFileserver.ingress.hostname }}
     http:

--- a/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
+++ b/charts/hauler/templates/hauler-registry/hauler-registry-ingress.yaml
@@ -24,6 +24,9 @@ metadata:
 {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.haulerRegistry.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.haulerRegistry.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.haulerRegistry.ingress.hostname }}
     http:

--- a/charts/hauler/values.yaml
+++ b/charts/hauler/values.yaml
@@ -84,6 +84,7 @@ haulerFileserver:
     #   key: value
     # annotations:
     #   key: value
+    # ingressClassName: ""  # optional... uses default ingress class
     hostname: fileserver.ranchers.io
     tls:
       enabled: false
@@ -113,6 +114,7 @@ haulerRegistry:
     #   key: value
     # annotations:
     #   key: value
+    # ingressClassName: ""  # optional... uses default ingress class
     hostname: registry.ranchers.io
     tls:
       enabled: false


### PR DESCRIPTION
- Added support for setting `ingressClassName` for the `hauler-registry` and `hauler-fileserver`
- Bumped chart version for `2.2.2` to `2.2.3` to kick off a new release